### PR TITLE
Fix bug that prevented User Rules from working, fix item-based user rule duplicating handlers.

### DIFF
--- a/core/RuleDSL.lua
+++ b/core/RuleDSL.lua
@@ -55,6 +55,7 @@ local ucfirst      = addon.ucfirst
 local errorhandler = addon.errorhandler
 local Do           = addon.Do
 local ConcatLists  = addon.ConcatLists
+local SubtractLists= addon.SubtractLists
 local FlattenList  = addon.FlattenList
 local AsList       = addon.AsList
 local AsSet        = addon.AsSet
@@ -132,6 +133,16 @@ local function _AddRuleFor(key, desc, spell, units, events, handlers, providers,
 		rules[id] = rule
 	end
 	if key then
+		if( _type == "item" ) then		--Some item rules survive wipes due to metatable shenanigans: Manually avoid duplication.
+			if( not rule.itemHandlers ) then rule.itemHandlers = {} end
+			if( rule.itemHandlers[key] ) then
+				SubtractLists(rule.keys, {key})		--remove duplicate key: it needs to be re-added after the wipe(), to appear in custom rules list
+				SubtractLists(rule.handlers, rule.itemHandlers[key])	--remove the old handlers that were added with this key
+			end
+
+			rule.itemHandlers[key] = handlers	--remember this key's handlers, so we can remove them next time
+		end
+
 		tinsert(rule.keys, key)
 		if not addon.db.profile.rules[key] then
 			return

--- a/core/Utils.lua
+++ b/core/Utils.lua
@@ -182,6 +182,19 @@ local function ConcatLists(a, b)
 end
 addon.ConcatLists = ConcatLists
 
+local function SubtractLists(a, b)
+	for ib, vb in ipairs(b) do
+		for ia, va in ipairs(a) do
+			if( va == vb ) then
+				tremove( a, ia )
+				break
+			end
+		end
+	end
+	return a
+end
+addon.SubtractLists = SubtractLists
+
 local FlattenList
 do
 	local function Flatten0(a, b)

--- a/rules/UserRules.lua
+++ b/rules/UserRules.lua
@@ -76,7 +76,11 @@ local function BuildUserRules()
 		end
 	end
 	initialLoading = false
-	return rules
+	
+	--Sub-builders for every user rule created. This parent builder can now run them.
+	for _, builder in ipairs(rules) do
+		xpcall(builder, errorhandler)
+	end
 end
 
 AdiButtonAuras:RegisterRules(function() return BuildUserRules end)

--- a/rules/UserRules.lua
+++ b/rules/UserRules.lua
@@ -76,7 +76,7 @@ local function BuildUserRules()
 		end
 	end
 	initialLoading = false
-	
+
 	--Sub-builders for every user rule created. This parent builder can now run them.
 	for _, builder in ipairs(rules) do
 		xpcall(builder, errorhandler)


### PR DESCRIPTION
UserRules.lua - Fix initializer/builder bug that prevented User Rules from working. (Adi already handled this, safe to discard)
Utils.lua - New function to remove elements of one list from another.
RuleDSL.lua - Fix rule creation-after-wipe logic to avoid duplicating handlers for some item-based User Rules.