### PR TITLE
Allow for coloring the count text when stacks reach their maximum

### DIFF
--- a/config/Theme.lua
+++ b/config/Theme.lua
@@ -133,6 +133,12 @@ function private.GetThemeOptions(addon, addonName)
 						type = 'color',
 						order = 50,
 					},
+					countAtMax = {
+						name = L['Count at maximum'],
+						desc = L['Color of the count text when it is at its maximum value.'],
+						type = 'color',
+						order = 60,
+					},
 				},
 			},
 			masque = masqueOption,

--- a/core/Core.lua
+++ b/core/Core.lua
@@ -85,6 +85,7 @@ addon.DEFAULT_SETTINGS = {
 			countdownLow    = { 1.0, 0.0, 0.0 },
 			countdownMedium = { 1.0, 1.0, 0.0 },
 			countdownHigh   = { 1.0, 1.0, 1.0 },
+			countAtMax      = { 1.0, 0.0, 0.0 },
 		},
 		maxCountdown = 600,
 		minMinutes = 600,

--- a/core/Display.lua
+++ b/core/Display.lua
@@ -221,11 +221,14 @@ function overlayPrototype:SetExpiration(expiration)
 	self:ApplyExpiration()
 end
 
-function overlayPrototype:SetCount(count)
+function overlayPrototype:SetCount(count, maxCount)
 	count = tonumber(count)
+	maxCount = tonumber(maxCount)
 	if count == 0 then count = nil end
+	if maxCount == 0 then maxCount = nil end
 	if self.count == count then return end
 	self.count = count
+	self.maxCount = maxCount
 	self:ApplyCount()
 end
 
@@ -261,9 +264,15 @@ end
 
 function overlayPrototype:ApplyCount()
 	local count = self.count
+	local maxCount = self.maxCount
 	self.Count:SetShown(count)
 	if count then
-		self.Count:SetFormattedText("%d", count)
+		self.Count:SetText(count)
+		if maxCount and count >= maxCount then
+			self.Count:SetTextColor(unpack(addon.db.profile.colors.countAtMax))
+		else
+			self.Count:SetTextColor(unpack(addon.db.profile.colors.countdownHigh))
+		end
 	end
 end
 

--- a/core/Overlays.lua
+++ b/core/Overlays.lua
@@ -440,7 +440,7 @@ local model = {}
 local modelProxy = setmetatable({}, {
 	__index = model,
 	__newindex = function(_, key, value)
-		if key == "count" or key == "expiration" then
+		if key == "count" or key == "maxCount" or key == "expiration" then
 			if type(value) ~= "number" then
 				return error(format("Invalid %s, should be a number, not %s", key, type(value)), 2)
 			end
@@ -459,7 +459,7 @@ local modelProxy = setmetatable({}, {
 				return error(format("Invalid %s, should be false or true, not %s", key, type(value)), 2)
 			end
 		else
-			return error(format('Unknown model property: %s, must be one of: count, expiration, highlight or hint', tostring(key)), 2)
+			return error(format('Unknown model property: %s, must be one of: count, maxCount, expiration, highlight or hint', tostring(key)), 2)
 		end
 		model[key] = value
 	end,
@@ -468,7 +468,7 @@ local modelProxy = setmetatable({}, {
 function overlayPrototype:UpdateState(event)
 	self:SetScript('OnUpdate', nil)
 
-	model.count, model.expiration, model.highlight, model.hint, model.flash  = 0, 0, nil, false, false
+	model.count, model.maxCount, model.expiration, model.highlight, model.hint, model.flash  = 0, 0, 0, nil, false, false
 
 	if self.handlers then
 		model.spellId, model.actionType, model.actionId = self.spellId, self.actionType, self.actionId
@@ -491,7 +491,7 @@ function overlayPrototype:UpdateState(event)
 		end
 	end
 
-	self:SetCount(model.count)
+	self:SetCount(model.count, model.maxCount)
 	self:SetExpiration(model.expiration)
 	self:SetHighlight(model.highlight)
 	self:SetFlash(model.flash)

--- a/core/RuleDSL.lua
+++ b/core/RuleDSL.lua
@@ -318,6 +318,7 @@ local function ShowCountAndHighlight(key, spells, unit, events, handler, highlig
 			local actualUnit = units[unit]
 			if not actualUnit then return end
 			local maxi = getMax(actualUnit)
+			model.maxCount = maxi
 			if maxi == 0 then return end
 			return handler(getValue(actualUnit), maxi, model, highlight)
 		end
@@ -330,6 +331,7 @@ local function ShowCountAndHighlight(key, spells, unit, events, handler, highlig
 		local count = getValue(actualUnit)
 		if not count or count == 0 then return end
 		model.count = count
+		model.maxCount = getMax(actualUnit)
 		return true
 	end
 	local showRule = Configure(key..'Display', format(L["Show %s."], descWhat), spells, unit, events, showHandler, providers, 4)
@@ -373,6 +375,7 @@ local function ShowCountAndHighlight(key, spells, unit, events, handler, highlig
 		local actualUnit = units[unit]
 		if not actualUnit then return end
 		local maxi = getMax(actualUnit)
+		model.maxCount = maxi
 		if maxi == 0 or not test(getValue(actualUnit), maxi) then return end
 		showHighlight(model)
 		return true


### PR DESCRIPTION
This could also be used as a kind of a second hint, e.g. suggest using Chaos Bolt (e.g. with rotary star) at 3 burning embers and warn (count text changes its color) when the player has all 4 burning embers. It could also be an alternative way to hint stuff like combo points for people who don't like animations.

It could be "disabled" by setting the color in the options to white.

It has a limitation though - it won't change the color if the default ui shows a stack or charge counter on the button, because ABA's count text is then hidden. I think setting the color of the default counter could cause taint but haven't tested it.