### PR TITLE
core: fix showing the stack count

### DIFF
--- a/core/Display.lua
+++ b/core/Display.lua
@@ -261,9 +261,11 @@ end
 
 function overlayPrototype:ApplyCount()
 	local count = self.count
-	self.Count:SetShown(count)
 	if count then
-		self.Count:SetFormattedText("%d", count)
+		self.Count:SetText(count)
+		self.Count:Show()
+	else
+		self.Count:Hide()
 	end
 end
 


### PR DESCRIPTION
Fixes https://github.com/Adirelle/AdiButtonAuras/issues/167

`SetShown` does not trigger the OnShow|Hide script handlers => LayoutTexts() is never called to check for the stock stack counter and hide ABA's own counter. Also, we need to set the text first and then check against it in LayoutTexts().