### PR TITLE
Added hint to Guard charges

### DIFF
--- a/rules/Monk.lua
+++ b/rules/Monk.lua
@@ -251,7 +251,7 @@ AdiButtonAuras:RegisterRules(function()
 					model.hint = true
 				end
 			end,
-		},	
+		},
 	}
 
 end)

--- a/rules/Monk.lua
+++ b/rules/Monk.lua
@@ -236,6 +236,22 @@ AdiButtonAuras:RegisterRules(function()
 				end
 			end,
 		},
+		Configure {
+			"GuardHint",
+			L["Show hint when your Guard charges max out."],
+			{
+				115295, -- Guard
+				123402, -- Guard (Glyph of Guard)
+			},
+			"player",
+			"SPELL_UPDATE_CHARGES",
+			function(_, model)
+				local currentCharges, maxCharges, _, _ = GetSpellCharges(115295)
+				if currentCharges == maxCharges then
+					model.hint = true
+				end
+			end,
+		},	
 	}
 
 end)

--- a/rules/Monk.lua
+++ b/rules/Monk.lua
@@ -268,3 +268,4 @@ end)
 -- GLOBALS: UnitHealth UnitHealthMax UnitIsDeadOrGhost UnitIsPlayer UnitPower
 -- GLOBALS: UnitPowerMax UnitStagger bit ceil floor format ipairs math min pairs
 -- GLOBALS: print select string table tinsert GetPlayerBuff ShowStacks
+-- GLOBALS: GetSpellCharges


### PR DESCRIPTION
Added an hint when Guard charges max out. The first charge is generally reserved by players for special boss attacks. While the second charge is mostly used when it is off CD, to prevent waste of damage reductions.