### PR TITLE
Added a hint for Touch of Death.

### DIFF
--- a/rules/Monk.lua
+++ b/rules/Monk.lua
@@ -252,6 +252,19 @@ AdiButtonAuras:RegisterRules(function()
 				end
 			end,
 		},
+			Configure {
+			"TouchOfDeathHint",
+			L["Show hint when Touch of Death can be cast."],
+			115080, -- Touch of Death
+			"player",
+			"UNIT_AURA",
+			function(_, model)
+				local found, _, _ = GetPlayerBuff("player", 121125) -- Death Note
+				if found then
+					model.hint = true
+				end
+			end,
+		},
 	}
 
 end)

--- a/rules/Monk.lua
+++ b/rules/Monk.lua
@@ -252,7 +252,7 @@ AdiButtonAuras:RegisterRules(function()
 				end
 			end,
 		},
-			Configure {
+		Configure {
 			"TouchOfDeathHint",
 			L["Show hint when Touch of Death can be cast."],
 			115080, -- Touch of Death


### PR DESCRIPTION
Please note that the button for Touch of Death is still tinted green when the buff "Death Note" is found. Please let me know if this default behaviour from LibPlayerSpells should be overruled. (If even possible.)