### PR TITLE
Added additional methods for showing missing Auras

### DIFF
--- a/config/Spells.lua
+++ b/config/Spells.lua
@@ -316,7 +316,7 @@ function private.GetSpellOptions(addon, addonName)
 				type = 'select',
 				values = {
 						none = L['Disabled'],
-						invert = L['Show border'],
+						highlight = L['Show border'],
 						flash = L['Show flash'],
 						hint = L['Show hint'],
 				},

--- a/config/Spells.lua
+++ b/config/Spells.lua
@@ -309,11 +309,23 @@ function private.GetSpellOptions(addon, addonName)
 				order = 20,
 				type = 'toggle',
 			},
-			inverted = {
-				name = L['Inverted'],
-				desc = L['Check to show a border when the (de)buff is missing.'],
+			missing = {
+				name = L['Show missing'],
+				desc = L['Select the method for showing missing (de)buffs.'],
 				order = 30,
-				type = 'toggle',
+				type = 'select',
+				values = {
+						none = L['Disabled'],
+						invert = L['Invert border'],
+						flash = L['Show flash'],
+						hint = L['Show hint'],
+				},
+				set = function(info, value)
+					handler:Set(info, value)
+					if value ~= 'none' and value ~= 'invert' then
+						addon.db.profile.flashPromotion[handler.current] = false
+					end
+				end,
 			},
 			flashPromotion = {
 				name = L['Show flash instead'],
@@ -321,6 +333,9 @@ function private.GetSpellOptions(addon, addonName)
 				order = 40,
 				type = 'toggle',
 				width = 'double',
+				disabled = function()
+					return addon.db.profile.missing[handler.current] ~= 'none' and addon.db.profile.missing[handler.current] ~= 'invert'
+				end,
 			},
 			rules = {
 				name = L['Rules'],

--- a/core/Core.lua
+++ b/core/Core.lua
@@ -77,7 +77,7 @@ addon.DEFAULT_SETTINGS = {
 	profile = {
 		enabled = { ['*'] = true },
 		rules = { ['*'] = true },
-		inverted = { ['*'] = false },
+		missing = { ['*'] = "none" },
 		flashPromotion = { ['*'] = false },
 		colors = {
 			good            = { 0.0, 1.0, 0.0, 0.7 },
@@ -233,6 +233,16 @@ function addon:ADDON_LOADED(event, name)
 		toWatch[addonName] = nil
 
 		self.db = GetLib('AceDB-3.0'):New(addonName.."DB", self.DEFAULT_SETTINGS, true)
+
+		if self.db.profile.inverted then
+			for key, inverted in pairs(self.db.profile.inverted) do
+				if inverted then
+					self.db.profile.missing[key] = "invert"
+				end
+			end
+			self.db.profile.inverted = nil
+		end
+
 		self.db.RegisterCallback(self, "OnProfileChanged")
 		self.db.RegisterCallback(self, "OnProfileCopied", "OnProfileChanged")
 		self.db.RegisterCallback(self, "OnProfileReset", "OnProfileChanged")

--- a/core/Core.lua
+++ b/core/Core.lua
@@ -242,7 +242,7 @@ function addon:ADDON_LOADED(event, name)
 					profile.missing[key] = "flash"
 					profile.flashPromotion[key] = nil
 				else
-					profile.missing[key] = "invert"
+					profile.missing[key] = "highlight"
 				end
 			end
 			profile.inverted = nil

--- a/core/Overlays.lua
+++ b/core/Overlays.lua
@@ -478,11 +478,19 @@ function overlayPrototype:UpdateState(event)
 			handler(unitMap, modelProxy)
 		end
 
-		if addon.db.profile.inverted[self.spellId] then
+		if addon.db.profile.missing[self.spellId] == "invert" then
 			if model.highlight then
 				model.highlight = nil
 			else
 				model.highlight = self.units.enemy and "bad" or "good"
+			end
+		end
+
+		if not model.highlight then
+			if addon.db.profile.missing[self.spellId] == "hint" then
+				model.hint = true
+			elseif addon.db.profile.missing[self.spellId] == "flash" then
+				model.flash = true
 			end
 		end
 

--- a/core/Overlays.lua
+++ b/core/Overlays.lua
@@ -478,7 +478,7 @@ function overlayPrototype:UpdateState(event)
 			handler(unitMap, modelProxy)
 		end
 
-		if addon.db.profile.missing[self.spellId] == "invert" then
+		if addon.db.profile.missing[self.spellId] == "highlight" then
 			if model.highlight then
 				model.highlight = nil
 			else


### PR DESCRIPTION
Added additional methods for showing missing Auras; as a hint or a flash.

Changed configuration options for spells. The inverted toggle was removed. A dropdown list for selecting the method for missing auras was added instead. This includes none, inverted, hint and flash.
Added logic for the promote toggle to be only applicable for the none and inverted methods. I doesn't make sense for the hint and flash methods.
Added some code to upgrade saved variables.